### PR TITLE
Add minStep to control classes

### DIFF
--- a/src/org/epics/pvdata/property/Control.java
+++ b/src/org/epics/pvdata/property/Control.java
@@ -27,6 +27,11 @@ public class Control {
      */
     public double getHigh() {return high;}
     /**
+     * Get control minStep.
+     * @return The value.
+     */
+    public double getMinStep() {return minStep;}
+    /**
      * Set control low.
      * @param value The value.
      */
@@ -36,8 +41,14 @@ public class Control {
      * @param value The value.
      */
     public void setHigh(double value) {high = value;}
+    /**
+     * Set control minStep.
+     * @param value The value.
+     */
+    public void setMinStep(double value) {minStep = value;}
     
     private double low = 0.0;
     private double high = 0.0;
+    private double minStep = 0.0;
 
 }

--- a/src/org/epics/pvdata/property/PVControlFactory.java
+++ b/src/org/epics/pvdata/property/PVControlFactory.java
@@ -18,6 +18,7 @@ import org.epics.pvdata.pv.Type;
 public final class PVControlFactory implements PVControl{
     private PVDouble pvLow = null;
     private PVDouble pvHigh = null;
+    private PVDouble pvMinStep = null;
     private static final String noControlFound = "No control structure was located";
     private static final String notAttached = "Not attached to an control structure";
 
@@ -45,6 +46,11 @@ public final class PVControlFactory implements PVControl{
             throw new IllegalArgumentException(noControlFound);
         }
         pvHigh = pvDouble;
+        pvDouble = pvStructure.getDoubleField("minStep");
+        if(pvDouble==null) {
+            throw new IllegalArgumentException(noControlFound);
+        }
+        pvMinStep = pvDouble;
         return true;
     }
     /* (non-Javadoc)
@@ -54,13 +60,14 @@ public final class PVControlFactory implements PVControl{
     public void detach() {
         pvLow = null;
         pvHigh = null;
+        pvMinStep = null;
     }
     /* (non-Javadoc)
      * @see org.epics.pvdata.property.PVControl#isAttached()
      */
     @Override
     public boolean isAttached() {
-        if(pvLow==null || pvHigh==null) return false;
+        if(pvLow==null || pvHigh==null || pvMinStep==null) return false;
         return true;
     }
     /* (non-Javadoc)
@@ -68,23 +75,25 @@ public final class PVControlFactory implements PVControl{
      */
     @Override
     public void get(Control control) {
-        if(pvLow==null || pvHigh==null) {
+        if(pvLow==null || pvHigh==null || pvMinStep==null) {
             throw new IllegalStateException(notAttached);
         }
         control.setLow(pvLow.get());
         control.setHigh(pvHigh.get());
+        control.setMinStep(pvMinStep.get());
     }
     /* (non-Javadoc)
      * @see org.epics.pvdata.property.PVControl#set(org.epics.pvdata.property.Control)
      */
     @Override
     public boolean set(Control control) {
-        if(pvLow==null || pvHigh==null) {
+        if(pvLow==null || pvHigh==null || pvMinStep==null) {
             throw new IllegalStateException(notAttached);
         }
         if(pvLow.isImmutable() || pvHigh.isImmutable()) return false;
         pvLow.put(control.getLow());
         pvHigh.put(control.getHigh());
+        pvMinStep.put(control.getMinStep());
         return true;
     }
 


### PR DESCRIPTION
The standard structure for control fields in the Normative Type Specification has a required "minStep" field in addition to ones for low and high values. The utility classes Control and PVControlFactory
in org.epics.pvdata.property had no support for the minStep field. This has been added in the same fashion as low and high and matches the C++ implementation behaviour.
