### PR TITLE
Add buffer capacity check in BasePVUnion.serialize

### DIFF
--- a/src/org/epics/pvdata/factory/BasePVUnion.java
+++ b/src/org/epics/pvdata/factory/BasePVUnion.java
@@ -207,7 +207,10 @@ public class BasePVUnion extends AbstractPVField implements PVUnion
 		{
 			// write introspection data
 			if (value == null)
+			{
+				flusher.ensureBuffer(1);
 				buffer.put((byte)-1);
+			}
 			else
 			{
 				flusher.cachedSerialize(value.getField(), buffer);


### PR DESCRIPTION
<p>Ensure room for writing 1 byte before serializing variant union with null value. Allows a buffer overflow in BasePVUnionArray.serialize(). Equivalent of commit <a href="https://github.com/epics-base/pvDataCPP/commit/14b0e409f21a7a0cda417734dd2ceab3d6c0e4a2">#14b0e40</a> in pvDataCPP.</p>


Fixes #5.
