### PR TITLE
unnecessary reallocation in BitSet::or_and removed, added tests

### DIFF
--- a/src/org/epics/pvdata/misc/BitSet.java
+++ b/src/org/epics/pvdata/misc/BitSet.java
@@ -947,7 +947,8 @@ public final class BitSet implements Cloneable, java.io.Serializable, org.epics.
 
         // ensure capacity
         if (wordsInUse < inUse) {
-            words = Arrays.copyOf(words, inUse);
+            if (inUse > words.length)
+            	words = Arrays.copyOf(words, inUse);
             wordsInUse = inUse;
         }
         

--- a/test/org/epics/pvdata/BitSetTest.java
+++ b/test/org/epics/pvdata/BitSetTest.java
@@ -44,6 +44,35 @@ public class BitSetTest extends TestCase {
 		assertEquals(src, dest);
 	}
 	
+	public void testOrAndBitSet() {
+	{
+		BitSet b1 = new BitSet(16);
+		assertEquals(0, b1.length());
+		b1.set(0);
+		assertEquals(1, b1.length());
+		
+
+		BitSet b2 = new BitSet(72);
+		b2.set(70);
+		b2.set(71);
+
+		BitSet b3 = new BitSet(72);
+		b3.set(71);
+		
+		// b1 will be expanded (reallocation)
+		b1.or_and(b2, b3);
+		assertEquals(2, b1.cardinality());
+		assertEquals(72, b1.length());
+		
+		// b1 will be expanded (no reallocation needed)
+		b1.clear();
+		b1.or_and(b2, b3);
+		assertEquals(1, b1.cardinality());
+		assertEquals(72, b1.length());
+	}
+
+	}
+	
 	static class SerControl implements SerializableControl, DeserializableControl
 	{
 


### PR DESCRIPTION
I've checked Java implementation for BitSet::or_and bug. The code is OK, but there is an unnecessary allocation that can be avoided. Fixed and tests added.
