### PR TITLE
remove postOut for scalarArray; channelPut always caused overrun bit …

### DIFF
--- a/src/org/epics/pvdata/factory/ConvertFactory.java
+++ b/src/org/epics/pvdata/factory/ConvertFactory.java
@@ -635,7 +635,6 @@ public final class ConvertFactory {
                 	        fromElementType, toElementType));
             }
             if(to.getLength()<count+offset) to.setLength(count+offset);
-            to.postPut();
             return ncopy;
         }
 


### PR DESCRIPTION
When a put us done to a scalar array an extra postPut was issued.
When a channelPut was issued for a scalarArray this resulted in the overrun bit set always being true for monitors.
